### PR TITLE
Remove cURL and use fetch + standard HTTP with follow-redirects expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "homepage": "https://github.com/t0rre/digilar#readme",
   "dependencies": {
+    "follow-redirects": "^1.13.3",
     "node-fetch": "^2.6.1",
-    "node-libcurl": "^2.3.0",
     "prompts": "^2.4.0",
     "uuid": "^8.3.2"
   }


### PR DESCRIPTION
All usage of cURL has been removed, this had to be done since it required manual libcurl installation on the user machine.
We're instead using fetch where it's possible, otherwise the standard Node.js https module is used (with follow-redirects).